### PR TITLE
Disable invest now before login

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -315,7 +315,8 @@
   function cardTemplate(l) {
     const pct = Math.min(100, Math.round((l.totalRaised / l.targetAmount) * 100));
     const admin = isAdmin();
-    const canInvest = !admin && l.status === 'Active';
+    const isInvestorUser = isInvestor();
+    const canInvest = isInvestorUser && l.status === 'Active';
     const ctaHref = admin ? `#` : `project-details.html?id=${encodeURIComponent(l.id)}`;
     const ctaLabel = admin ? 'Edit Property' : (canInvest ? 'Invest Now' : 'View Details');
     const ctaClass = admin
@@ -425,6 +426,21 @@
         showInfo('Please login or sign up to start investing');
         modal.classList.remove('hidden'); 
         modal.classList.add('flex'); 
+      }
+    });
+
+    // Intercept featured card CTAs for unauthenticated users
+    const featuredGrid = byId('featuredGrid');
+    featuredGrid && featuredGrid.addEventListener('click', (e) => {
+      const link = e.target.closest('a[data-cta]');
+      if (!link) return;
+      if (!isInvestor() && !isAdmin()) {
+        e.preventDefault();
+        showInfo('Please login or sign up to invest');
+        if (modal) {
+          modal.classList.remove('hidden');
+          modal.classList.add('flex');
+        }
       }
     });
 


### PR DESCRIPTION
Restrict 'Invest Now' actions on the homepage to authenticated users.

Unauthenticated users will no longer see 'Invest Now' on property cards and clicking any featured property CTA will prompt them to log in or sign up.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc311122-00c9-428d-9a31-0727fb72bc24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc311122-00c9-428d-9a31-0727fb72bc24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

